### PR TITLE
Restructure module files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,9 @@
+`use strict`
+
+var moment = require('moment');
+var Chart = require('chart.js');
+var randomColor = requrie('randomcolor');
+
 function convertToChartData(sessions){
   //need to know labels
   var labels = [];
@@ -62,7 +68,7 @@ function convertToChartData(sessions){
   return chartData;
 }
 
-function createOutcomeChart(div, title, data){
+function createOutcomeGraph(div, title, data){
   var chartConfig = createConfig(data,title);
   return new Chart(document.getElementById(div), chartConfig);
 }
@@ -97,3 +103,5 @@ function createConfig(data, title){
     }
   };
 }
+
+module.exports.createOutcomeGraph = createOutcomeGraph;

--- a/test/index.html
+++ b/test/index.html
@@ -21,7 +21,7 @@
   <script src='https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.1/moment.min.js'></script>
   <script src='https://cdnjs.cloudflare.com/ajax/libs/randomcolor/0.4.4/randomColor.min.js'></script>
   <script src='./test-data.js'></script>
-  <script src='../src/graph-library.js'></script>
+  <script src='../src/index.js'></script>
   <script src='./main.js'></script>
 
   </body>

--- a/test/main.js
+++ b/test/main.js
@@ -1,3 +1,3 @@
 window.onload = function() {
-  window.myRadar = createOutcomeChart("canvas", "Outcome Graph", testData);
+  window.myRadar = createOutcomeGraph("canvas", "Outcome Graph", testData);
 };


### PR DESCRIPTION
This change moves all functions for the library to the `index.js` file and
exports only the `createOutcomeGraph` function for use. The test
`index.html` page has been updated with references accordingly.