### PR TITLE
Remove unused import and tweak sessionsConverter export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var Chart = require('chart.js');
-var sessionsConverter = require('./sessionsConverter.js');
+var sessionsConverter = require('./sessionsConverter.js')();
 
 function getOutcomeGraph(div, title, data){
   var chartConfig = getConfig(data,title);

--- a/src/sessionsConverter.js
+++ b/src/sessionsConverter.js
@@ -2,11 +2,10 @@
 
 var color = require('chartjs-color');
 var moment = require('moment');
-var randomColor = require('randomcolor');
 var distinctColors = require('distinct-colors')
 
 // module pattern
-var sessionsConverter = function (){
+module.exports = function (){
   // variable to keep track of different labels
   var labels = [];
   // labels set for checking if label is unique
@@ -123,5 +122,3 @@ var sessionsConverter = function (){
     }
   };
 };
-
-module.exports = new sessionsConverter();


### PR DESCRIPTION
This change removes the unused `randomColor` import that was erroneously
left in the last change. It also removes the instantiation of sessionsConverter, 
instead doing that in the `index.js` file