### PR TITLE
Add cleaning

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "browserify": "14.3.0",
+    "rimraf": "2.6.1",
     "uglifyjs": "2.4.10"
   },
   "scripts": {
@@ -25,6 +26,8 @@
     "build:bundle": "browserify ./src/index.js --standalone outcomeGraph > ./dist/outcome-graph.bundle.js",
     "build:module-minified": "uglifyjs ./dist/outcome-graph.js -mc > ./dist/outcome-graph.min.js",
     "build:bundle-minified": "uglifyjs ./dist/outcome-graph.bundle.js -mc > ./dist/outcome-graph.bundle.min.js",
+    "build:clean": "rimraf ./dist/*",
+    "prebuild": "npm run build:clean",
     "build": "npm run build:module && npm run build:module-minified && npm run build:bundle && npm run build:bundle-minified"
   }
 }


### PR DESCRIPTION
This change adds a script to clean the `dist` folder when building the
library into UMD and its bundle. It also adds a `prebuild` script so that
when we run `build`, it automatically clean the folder before building.